### PR TITLE
UTxO map deserialisation fixes, from seq handling, seq moved to response

### DIFF
--- a/src/main/java/org/cardanofoundation/hydra/client/ResponseTagHandlers.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/ResponseTagHandlers.java
@@ -32,6 +32,7 @@ public class ResponseTagHandlers {
         handlers.put(Tag.PostTxOnChainFailed, PostTxOnChainFailedResponse::create);
         handlers.put(Tag.RolledBack, RolledbackResponse::create);
         handlers.put(Tag.CommandFailed, CommandFailedResponse::create);
+        handlers.put(Tag.SnapshotConfirmed, SnapshotConfirmed::create);
     }
 
     public Optional<Function<JsonNode, Response>> responseHandlerFor(Tag tag) {

--- a/src/main/java/org/cardanofoundation/hydra/client/model/Snapshot.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/Snapshot.java
@@ -1,5 +1,6 @@
 package org.cardanofoundation.hydra.client.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,6 +8,7 @@ import java.util.Map;
 
 @Getter
 @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Snapshot {
 
     private int snapshotNumber;

--- a/src/main/java/org/cardanofoundation/hydra/client/model/Transaction.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/Transaction.java
@@ -3,12 +3,14 @@ package org.cardanofoundation.hydra.client.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.util.List;
 
 @Getter
 @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
+@ToString
 public class Transaction {
 
     String id;

--- a/src/main/java/org/cardanofoundation/hydra/client/model/UTXO.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/UTXO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.math.BigInteger;
 import java.util.Map;
@@ -11,6 +12,7 @@ import java.util.Map;
 @Getter
 @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
+@ToString
 public class UTXO {
     String address;
     Map<String, BigInteger> value;

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/CommandFailedResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/CommandFailedResponse.java
@@ -23,7 +23,7 @@ public class CommandFailedResponse extends Response {
     public CommandFailedResponse(int seq,
                                  LocalDateTime timestamp,
                                  JsonNode clientInput) {
-        super(Tag.CommandFailed);
+        super(Tag.CommandFailed, seq);
         this.seq = seq;
         this.timestamp = timestamp;
         this.clientInput = clientInput;

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/CommittedResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/CommittedResponse.java
@@ -20,21 +20,18 @@ public class CommittedResponse extends Response {
     private final Party party;
     private final Map<String, UTXO> utxo;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     public CommittedResponse(Party party, Map<String, UTXO> utxo, int seq, LocalDateTime timestamp) {
-        super(Tag.Committed);
+        super(Tag.Committed, seq);
         this.party = party;
         this.utxo = utxo;
-        this.seq = seq;
         this.timestamp = timestamp;
     }
 
     public static CommittedResponse create(JsonNode raw) {
         val party = MoreJson.convert(raw.get("party"), Party.class);
-        val utxo = MoreJson.<UTXO>convertStringMap(raw.get("utxo"));
+        val utxo = MoreJson.convertUTxOMap(raw.get("utxo"));
         val seq = raw.get("seq").asInt();
         val timestamp = MoreJson.convert(raw.get("timestamp"), LocalDateTime.class);
 

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/GetUTxOResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/GetUTxOResponse.java
@@ -18,22 +18,19 @@ public class GetUTxOResponse extends Response {
 
     private final String headId;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     private final Map<String, UTXO> utxo;
 
     public GetUTxOResponse(String headId, int seq, LocalDateTime timestamp, Map<String, UTXO> utxo) {
-        super(Tag.GetUTxOResponse);
+        super(Tag.GetUTxOResponse, seq);
         this.headId = headId;
-        this.seq = seq;
         this.timestamp = timestamp;
         this.utxo = utxo;
     }
 
     public static GetUTxOResponse create(JsonNode raw) {
-        val utxo = MoreJson.<UTXO>convertStringMap(raw.get("utxo"));
+        val utxo = MoreJson.convertUTxOMap(raw.get("utxo"));
 
         val headId = raw.get("headId").asText();
         val seq = raw.get("seq").asInt();

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/GreetingsResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/GreetingsResponse.java
@@ -16,13 +16,11 @@ import java.time.LocalDateTime;
 public class GreetingsResponse extends Response {
 
     private final Party me;
-    private final int seq;
     private final LocalDateTime timestamp;
 
     public GreetingsResponse(Party party, int seq, LocalDateTime timestamp) {
-        super(Tag.Greetings);
+        super(Tag.Greetings, seq);
         this.me = party;
-        this.seq = seq;
         this.timestamp = timestamp;
     }
 

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsAbortedResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsAbortedResponse.java
@@ -18,22 +18,19 @@ public class HeadIsAbortedResponse extends Response {
 
     private final String headId;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     private final Map<String, UTXO> utxo;
 
     public HeadIsAbortedResponse(String headId, int seq, LocalDateTime timestamp, Map<String, UTXO> utxo) {
-        super(Tag.HeadIsAborted);
+        super(Tag.HeadIsAborted, seq);
         this.headId = headId;
-        this.seq = seq;
         this.timestamp = timestamp;
         this.utxo = utxo;
     }
 
     public static HeadIsAbortedResponse create(JsonNode raw) {
-        val utxo = MoreJson.<UTXO>convertStringMap(raw.get("utxo"));
+        val utxo = MoreJson.convertUTxOMap(raw.get("utxo"));
         val headId = raw.get("headId").asText();
         val seq = raw.get("seq").asInt();
         val timestamp = MoreJson.convert(raw.get("timestamp"), LocalDateTime.class);

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsClosedResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsClosedResponse.java
@@ -20,8 +20,6 @@ public class HeadIsClosedResponse extends Response {
 
     private final String headId;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     public HeadIsClosedResponse(String headId,
@@ -29,11 +27,10 @@ public class HeadIsClosedResponse extends Response {
                                 LocalDateTime contestationDeadline,
                                 int seq,
                                 LocalDateTime timestamp) {
-        super(Tag.HeadIsClosed);
+        super(Tag.HeadIsClosed, seq);
         this.headId = headId;
         this.snapshotNumber = snapshotNumber;
         this.contestationDeadline = contestationDeadline;
-        this.seq = seq;
         this.timestamp = timestamp;
     }
 

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsContestedResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsContestedResponse.java
@@ -18,16 +18,13 @@ public class HeadIsContestedResponse extends Response {
 
     private final String headId;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     private final int snapshotNumber;
 
     public HeadIsContestedResponse(String headId, int seq, LocalDateTime timestamp, int snapshotNumber) {
-        super(Tag.HeadIsClosed);
+        super(Tag.HeadIsClosed, seq);
         this.headId = headId;
-        this.seq = seq;
         this.timestamp = timestamp;
         this.snapshotNumber = snapshotNumber;
     }

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsFinalizedResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsFinalizedResponse.java
@@ -18,22 +18,19 @@ public class HeadIsFinalizedResponse extends Response {
 
     private final String headId;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     private final Map<String, UTXO> utxo;
 
     public HeadIsFinalizedResponse(String headId, int seq, LocalDateTime timestamp, Map<String, UTXO> utxo) {
-        super(Tag.HeadIsFinalized);
+        super(Tag.HeadIsFinalized, seq);
         this.headId = headId;
-        this.seq = seq;
         this.timestamp = timestamp;
         this.utxo = utxo;
     }
 
     public static HeadIsFinalizedResponse create(JsonNode raw) {
-        val utxo = MoreJson.<UTXO>convertStringMap(raw.get("utxo"));
+        val utxo = MoreJson.convertUTxOMap(raw.get("utxo"));
         val headId = raw.get("headId").asText();
         val seq = raw.get("seq").asInt();
         val timestamp = MoreJson.convert(raw.get("timestamp"), LocalDateTime.class);

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsInitializingResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsInitializingResponse.java
@@ -20,15 +20,12 @@ public class HeadIsInitializingResponse extends Response {
 
     private final String headId;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     public HeadIsInitializingResponse(String headId, List<Party> parties, int seq, LocalDateTime timestamp) {
-        super(Tag.HeadIsInitializing);
+        super(Tag.HeadIsInitializing, seq);
         this.headId = headId;
         this.parties = parties;
-        this.seq = seq;
         this.timestamp = timestamp;
     }
 

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsOpenResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsOpenResponse.java
@@ -20,21 +20,18 @@ public class HeadIsOpenResponse extends Response {
 
     private final Map<String, UTXO> utxo;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     public HeadIsOpenResponse(String headId, Map<String, UTXO> utxo, int seq, LocalDateTime timestamp) {
-        super(Tag.HeadIsOpen);
+        super(Tag.HeadIsOpen, seq);
         this.headId = headId;
         this.utxo = utxo;
-        this.seq = seq;
         this.timestamp = timestamp;
     }
 
     public static HeadIsOpenResponse create(JsonNode raw) {
         val utxoNode = raw.get("utxo");
-        val utxoMap = MoreJson.<UTXO>convertStringMap(utxoNode);
+        val utxoMap = MoreJson.convertUTxOMap(utxoNode);
         val headId = raw.get("headId").asText();
         val seq = raw.get("seq").asInt();
         val timestamp = MoreJson.convert(raw.get("timestamp"), LocalDateTime.class);

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/InvalidInputResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/InvalidInputResponse.java
@@ -14,16 +14,13 @@ import java.time.LocalDateTime;
 @ToString(callSuper = true)
 public class InvalidInputResponse extends Response {
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     private final String reason;
     private final String input;
 
     public InvalidInputResponse(int seq, LocalDateTime timestamp, String reason, String input) {
-        super(Tag.InvalidInput);
-        this.seq = seq;
+        super(Tag.InvalidInput, seq);
         this.timestamp = timestamp;
         this.reason = reason;
         this.input = input;

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/PeerConnectedResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/PeerConnectedResponse.java
@@ -16,14 +16,11 @@ public class PeerConnectedResponse extends Response {
 
     private final String peer;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     public PeerConnectedResponse(String peer, int seq, LocalDateTime timestamp) {
-        super(Tag.PeerConnected);
+        super(Tag.PeerConnected, seq);
         this.peer = peer;
-        this.seq = seq;
         this.timestamp = timestamp;
     }
 

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/PeerDisconnectedResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/PeerDisconnectedResponse.java
@@ -16,14 +16,11 @@ public class PeerDisconnectedResponse extends Response {
 
     private final String peer;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     public PeerDisconnectedResponse(String peer, int seq, LocalDateTime timestamp) {
-        super(Tag.PeerDisconnected);
+        super(Tag.PeerDisconnected, seq);
         this.peer = peer;
-        this.seq = seq;
         this.timestamp = timestamp;
     }
 

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/PostTxOnChainFailedResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/PostTxOnChainFailedResponse.java
@@ -15,13 +15,10 @@ import java.time.LocalDateTime;
 @ToString(callSuper = true)
 public class PostTxOnChainFailedResponse extends Response {
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     public PostTxOnChainFailedResponse(int seq, LocalDateTime timestamp) {
-        super(Tag.PostTxOnChainFailed);
-        this.seq = seq;
+        super(Tag.PostTxOnChainFailed, seq);
         this.timestamp = timestamp;
     }
 

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/ReadyToFanoutResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/ReadyToFanoutResponse.java
@@ -17,14 +17,11 @@ public class ReadyToFanoutResponse extends Response {
 
     private final String headId;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     public ReadyToFanoutResponse(String headId, int seq, LocalDateTime timestamp) {
-        super(Tag.ReadyToFanout);
+        super(Tag.ReadyToFanout, seq);
         this.headId = headId;
-        this.seq = seq;
         this.timestamp = timestamp;
     }
 

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/Response.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/Response.java
@@ -7,14 +7,16 @@ import org.cardanofoundation.hydra.client.model.Tag;
 public class Response {
 
     protected final Tag tag;
+    protected final int seq;
 
-    protected Response(Tag tag) {
+    protected Response(Tag tag, int seq) {
         this.tag = tag;
+        this.seq = seq;
     }
 
     @Override
     public String toString() {
-        return tag.name();
+        return String.format("{tag:%s, seq:%s}", tag.name(), seq);
     }
 
 }

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/RolledbackResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/RolledbackResponse.java
@@ -14,13 +14,10 @@ import java.time.LocalDateTime;
 @ToString(callSuper = true)
 public class RolledbackResponse extends Response {
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     public RolledbackResponse(int seq, LocalDateTime timestamp) {
-        super(Tag.RolledBack);
-        this.seq = seq;
+        super(Tag.RolledBack, seq);
         this.timestamp = timestamp;
     }
 

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/SnapshotConfirmed.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/SnapshotConfirmed.java
@@ -17,16 +17,13 @@ public class SnapshotConfirmed extends Response {
 
     private final String headId;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     private final Snapshot snapshot;
 
     public SnapshotConfirmed(String headId, int seq, LocalDateTime timestamp, Snapshot snapshot) {
-        super(Tag.SnapshotConfirmed);
+        super(Tag.SnapshotConfirmed, seq);
         this.headId = headId;
-        this.seq = seq;
         this.timestamp = timestamp;
         this.snapshot = snapshot;
     }

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/TxInvalidResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/TxInvalidResponse.java
@@ -21,8 +21,6 @@ public class TxInvalidResponse extends Response {
 
     private final String headId;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     private final Map<String, UTXO> utxo;
@@ -35,9 +33,8 @@ public class TxInvalidResponse extends Response {
                              Map<String, UTXO> utxo,
                              Transaction transaction,
                              ValidationError validationError) {
-        super(Tag.TxInvalid);
+        super(Tag.TxInvalid, seq);
         this.headId = headId;
-        this.seq = seq;
         this.timestamp = timestamp;
         this.utxo = utxo;
         this.transaction = transaction;
@@ -45,7 +42,7 @@ public class TxInvalidResponse extends Response {
     }
 
     public static TxInvalidResponse create(JsonNode raw) {
-        val utxo = MoreJson.<UTXO>convertStringMap(raw.get("utxo"));
+        val utxo = MoreJson.convertUTxOMap(raw.get("utxo"));
         val transaction = MoreJson.convert(raw.get("transaction"), Transaction.class);
         val validationError = MoreJson.convert(raw.get("validationError"), ValidationError.class);
         val headId = raw.get("headId").asText();

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/TxValidResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/TxValidResponse.java
@@ -19,15 +19,12 @@ public class TxValidResponse extends Response {
 
     private final String headId;
 
-    private final int seq;
-
     private final LocalDateTime timestamp;
 
     public TxValidResponse(Transaction transaction, String headId, int seq, LocalDateTime timestamp) {
-        super(Tag.TxValid);
+        super(Tag.TxValid, seq);
         this.transaction = transaction;
         this.headId = headId;
-        this.seq = seq;
         this.timestamp = timestamp;
     }
 

--- a/src/main/java/org/cardanofoundation/hydra/client/util/MoreJson.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/util/MoreJson.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.cardanofoundation.hydra.client.HydraException;
+import org.cardanofoundation.hydra.client.model.UTXO;
 
 import java.util.List;
 import java.util.Map;
@@ -47,9 +48,8 @@ public class MoreJson {
             throw new HydraException("Unable to deserialise json", e);
         }
     }
-
-    public static <T> Map<String, T> convertStringMap(JsonNode o) throws HydraException {
-        return MAPPER.convertValue(o, new TypeReference<Map<String, T>>(){});
+    public static Map<String, UTXO> convertUTxOMap(JsonNode o) throws HydraException {
+        return MAPPER.convertValue(o, new TypeReference<Map<String, UTXO>>(){});
     }
 
     public static <T> List<T> convertList(JsonNode o) throws HydraException {

--- a/src/test/java/org/cardanofoundation/hydra/client/HydraWSClientIntegrationTest.java
+++ b/src/test/java/org/cardanofoundation/hydra/client/HydraWSClientIntegrationTest.java
@@ -20,7 +20,7 @@ class HydraWSClientIntegrationTest {
 
     @BeforeAll
     void initClient() throws InterruptedException, URISyntaxException {
-        hydraWSClient = new HydraWSClient(new URI("ws://dev.cf-hydra-voting-poc.metadata.dev.cf-deployments.org:4001"));
+        hydraWSClient = new HydraWSClient(new URI("ws://dev.cf-hydra-voting-poc.metadata.dev.cf-deployments.org:4001"), 383);
         hydraWSClient.setHydraQueryEventListener(response -> log.info("response:{}", response));
         hydraWSClient.setHydraStateEventListener((prev, now) -> log.info("prev:{}, now:{}", prev, now));
         hydraWSClient.connectBlocking(60, TimeUnit.SECONDS);
@@ -30,7 +30,7 @@ class HydraWSClientIntegrationTest {
     void init() throws InterruptedException {
         val l = new CountDownLatch(10);
 
-        l.await(5, TimeUnit.SECONDS);
+        l.await(10, TimeUnit.SECONDS);
     }
 
     @AfterAll


### PR DESCRIPTION
1. UTxO map should properly deserialise now
2. Bug fix: SnapshotConfirmed was actually not added to response handlers
3. Added fromSeq, which allows client to pass from where to replay messages
4. seq moved to response class, where it belongs since all responses have seq (int)