### PR TITLE
history=0; use GreetingsResponse to get Hydra Head state

### DIFF
--- a/src/main/java/org/cardanofoundation/hydra/client/HydraClientOptions.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/HydraClientOptions.java
@@ -14,7 +14,7 @@ public class HydraClientOptions {
     private int fromSeq = 0;
 
     @Builder.Default
-    private boolean history = true;
+    private boolean history = false;
 
     @Nullable
     private TransactionFormat transactionFormat;

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/GreetingsResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/GreetingsResponse.java
@@ -4,11 +4,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.val;
+import org.cardanofoundation.hydra.client.model.HydraState;
 import org.cardanofoundation.hydra.client.model.Party;
 import org.cardanofoundation.hydra.client.model.Tag;
+import org.cardanofoundation.hydra.client.model.UTXO;
 import org.cardanofoundation.hydra.client.util.MoreJson;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 // A friendly welcome message which tells a client something about the node. Currently used for knowing what Party the server embodies. This message produced whenever the hydra-node starts and clients should take consequence of seeing this. For example, we can assume no peers connected when we see 'Greetings'.
 @Getter
@@ -16,20 +19,37 @@ import java.time.LocalDateTime;
 public class GreetingsResponse extends Response {
 
     private final Party me;
+
     private final LocalDateTime timestamp;
 
-    public GreetingsResponse(Party party, int seq, LocalDateTime timestamp) {
+    private final HydraState headStatus;
+
+    private final Map<String, UTXO> snapshotUtxo;
+
+    public GreetingsResponse(Party party,
+                             int seq,
+                             LocalDateTime timestamp,
+                             HydraState headStatus,
+                             Map<String, UTXO> snapshotUtxo) {
         super(Tag.Greetings, seq);
         this.me = party;
         this.timestamp = timestamp;
+        this.headStatus = headStatus;
+        this.snapshotUtxo = snapshotUtxo;
     }
 
     public static GreetingsResponse create(JsonNode raw) {
         val party = MoreJson.convert(raw.get("me"), Party.class);
         val seq = raw.get("seq").asInt();
         val timestamp = MoreJson.convert(raw.get("timestamp"), LocalDateTime.class);
+        val headStatus = MoreJson.convert(raw.get("headStatus"), HydraState.class);
+        if (raw.has("snapshotUtxo")) {
+            val utxo = MoreJson.convertUTxOMap(raw.get("snapshotUtxo"));
 
-        return new GreetingsResponse(party, seq, timestamp);
+            return new GreetingsResponse(party, seq, timestamp, headStatus, utxo);
+        }
+
+        return new GreetingsResponse(party, seq, timestamp, headStatus, Map.of());
     }
 
 }

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsOpenResponse.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/HeadIsOpenResponse.java
@@ -22,7 +22,9 @@ public class HeadIsOpenResponse extends Response {
 
     private final LocalDateTime timestamp;
 
-    public HeadIsOpenResponse(String headId, Map<String, UTXO> utxo, int seq, LocalDateTime timestamp) {
+    public HeadIsOpenResponse(String headId,
+                              Map<String, UTXO> utxo,
+                              int seq, LocalDateTime timestamp) {
         super(Tag.HeadIsOpen, seq);
         this.headId = headId;
         this.utxo = utxo;
@@ -30,8 +32,7 @@ public class HeadIsOpenResponse extends Response {
     }
 
     public static HeadIsOpenResponse create(JsonNode raw) {
-        val utxoNode = raw.get("utxo");
-        val utxoMap = MoreJson.convertUTxOMap(utxoNode);
+        val utxoMap = MoreJson.convertUTxOMap(raw.get("utxo"));
         val headId = raw.get("headId").asText();
         val seq = raw.get("seq").asInt();
         val timestamp = MoreJson.convert(raw.get("timestamp"), LocalDateTime.class);

--- a/src/main/java/org/cardanofoundation/hydra/client/model/query/response/SnapshotConfirmed.java
+++ b/src/main/java/org/cardanofoundation/hydra/client/model/query/response/SnapshotConfirmed.java
@@ -21,7 +21,10 @@ public class SnapshotConfirmed extends Response {
 
     private final Snapshot snapshot;
 
-    public SnapshotConfirmed(String headId, int seq, LocalDateTime timestamp, Snapshot snapshot) {
+    public SnapshotConfirmed(String headId,
+                             int seq,
+                             LocalDateTime timestamp,
+                             Snapshot snapshot) {
         super(Tag.SnapshotConfirmed, seq);
         this.headId = headId;
         this.timestamp = timestamp;


### PR DESCRIPTION
Following Hydra support for adding hydra state and snapshot in the Greetings message (https://github.com/input-output-hk/hydra/issues/823), this PR adds hydra state handing in case history is disabled.

Please keep in mind that at the moment upstream clients have to take care of Snapshot themselves, HydraWSClient is rather low level and doesn't provide UTxOStore.

@satran004 this PR made me realise it would be awesome to have something like yaci-test with test container support but for Hydra as well.

Alternatively since Hydra is actually nothing else than websocket connection, I can provide myself with integration tests using some mock websocket enabled server (which will be way easier than supporting yaci-test-hydra I guess).